### PR TITLE
Implemented logout, bio, location. Resolved a session table validation bug.

### DIFF
--- a/api/endpoints/userprofiles.py
+++ b/api/endpoints/userprofiles.py
@@ -34,11 +34,24 @@ def login(request):
             status=401
         )
     else:
+        if "uemail" in request.session:
+            logout(request)
         request.session["uemail"] = user.email
         return HttpResponse(
             "Login acknowledged",
             status=200
         )
+
+# URI: /api/logout
+# Expect:
+def logout(request):
+    if "uemail" in request.session:
+        del request.session["uemail"]
+        return HttpResponse(
+            "Logout acknowledged",
+            status=200
+        )
+    return httpBadRequest()
 
 # URI: /api/signup
 # Expect: email, oauthid, name, photourl, location, bio
@@ -85,8 +98,21 @@ def setbio(request):
     except UnexpectedContentException:
         return httpBadRequest()
     
-    # Not implemented.
-    return HttpResponse("Not implemented", status=501)
+    user = None
+    try:
+        user = User.objects.get(email=request.session["uemail"])
+    except (ObjectDoesNotExist, KeyError):
+        return HttpResponse(
+            "Unauthorized",
+            status=401
+        )
+    
+    user.bio = json_req["bio"]
+    user.save()
+    return HttpResponse(
+        "Bio updated",
+        status=200
+    )
 
 # URI: /api/setlocation
 # Expect: newlocation
@@ -98,5 +124,18 @@ def setlocation(request):
     except UnexpectedContentException:
         return httpBadRequest()
     
-    # Not implemented.
-    return HttpResponse("Not implemented", status=501)
+    user = None
+    try:
+        user = User.objects.get(email=request.session["uemail"])
+    except (ObjectDoesNotExist, KeyError):
+        return HttpResponse(
+            "Unauthorized",
+            status=401
+        )
+    
+    user.location = json_req["location"]
+    user.save()
+    return HttpResponse(
+        "Location updated",
+        status=200
+    )

--- a/api/models.py
+++ b/api/models.py
@@ -4,9 +4,12 @@ from django.dispatch import receiver
 from django.db.models.signals import pre_save
 import uuid
 
+validated_models = ["User", "Task", "Swipe", "Conversation", "Message"]
+
 @receiver(pre_save)
 def pre_save_handler(sender, instance, *args, **kwargs):
-    instance.full_clean()
+    if type(instance).__name__ in validated_models:
+        instance.full_clean()
 
 class User(Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/api/tests/tests_userprofile.py
+++ b/api/tests/tests_userprofile.py
@@ -243,7 +243,7 @@ class SetLocationTests(TestCase):
                                         }),
                                         content_type='application/json')
         self.assertEqual(User.objects.get(email="jon@example.com").location, "Madrid")
-        self.assertEqual(response.status_code, 200) # Unimplemented, expect fail.
+        self.assertEqual(response.status_code, 200)
 
     def test_setlocation_malformed_json(self):
         response = self.client.generic('GET',

--- a/api/urls.py
+++ b/api/urls.py
@@ -7,6 +7,7 @@ app_name = "api"
 urlpatterns = [
     path('', views.index, name='index'),
     path('login', userprofiles.login, name='login'),
+    path('logout', userprofiles.logout, name='logout'),
     path('signup', userprofiles.signup, name='signup'),
     path('setbio', userprofiles.setbio, name='setbio'),
     path('setlocation', userprofiles.setlocation, name='setlocation'),


### PR DESCRIPTION
Closes #6, #7, #8 .
Sending this one out a bit early to address an important bug introduced with the forced model validation change.

Changelist:
- Implemented endpoints for logout, setbio, setlocation.
- Resolves an issue with the forced validation override; this was added so that Django would compel table changes to be valid. This should only be done for tables *we* create - sessions were malfunctioning because of this, so this change explicitly forces validation only for a whitelist of tables we define.

TESTED_HOW: All unit tests passing, validated added endpoints with Postman.

Reviewers: @harungunaydin 
